### PR TITLE
Present a list of supported regions when creating

### DIFF
--- a/custom_components/amazon_cloudwatch/config_flow.py
+++ b/custom_components/amazon_cloudwatch/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
+from .const import DOMAIN, SUPPORTED_REGIONS
 
 import boto3
 import botocore
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("aws_region"): str,
+        vol.Required("aws_region"): vol.In(SUPPORTED_REGIONS),
         vol.Required("aws_access_key_id"): str,
         vol.Required("aws_secret_access_key"): str,
     }
@@ -39,13 +39,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    # TODO validate the data can be used to set up a connection.
-
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data["username"], data["password"]
-    # )
+    # This only checks that the credentials are valid, not that they
+    # can write to CloudWatch
 
     try:
         caller = await hass.async_add_executor_job(check_aws_credentials,
@@ -63,8 +58,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Amazon CloudWatch."""
-
-    VERSION = 1
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/amazon_cloudwatch/const.py
+++ b/custom_components/amazon_cloudwatch/const.py
@@ -1,3 +1,37 @@
 """Constants for the Amazon CloudWatch integration."""
 
 DOMAIN = "amazon_cloudwatch"
+
+# List is from https://docs.aws.amazon.com/general/latest/gr/cw_region.html
+SUPPORTED_REGIONS = [
+    'us-east-1',
+    'us-east-2',
+    'us-west-1',
+    'us-west-2',
+    'af-south-1',
+    'ap-east-1',
+    'ap-south-2',
+    'ap-southeast-3',
+    'ap-southeast-4',
+    'ap-south-1',
+    'ap-northeast-3',
+    'ap-northeast-2',
+    'ap-southeast-1',
+    'ap-southeast-2',
+    'ap-northeast-1',
+    'ca-central-1',
+    'eu-central-1',
+    'eu-west-1',
+    'eu-west-2',
+    'eu-south-1',
+    'eu-west-3',
+    'eu-south-2',
+    'eu-north-1',
+    'eu-central-2',
+    'il-central-1',
+    'me-south-1',
+    'me-central-1',
+    'sa-east-1',
+    'us-gov-east-1',
+    'us-gov-west-1',
+]

--- a/custom_components/amazon_cloudwatch/translations/en.json
+++ b/custom_components/amazon_cloudwatch/translations/en.json
@@ -7,9 +7,7 @@
                     "aws_access_key_id": "AWS access key ID",
                     "aws_secret_access_key": "AWS secret access key"
                 },
-                "data_description": {
-                    "aws_region": "In the format 'us-east-1'"
-                }
+                "data_description": {}
             }
         },
         "error": {


### PR DESCRIPTION
To avoid issues with the different ways to write the names of regions, this switches to presenting a list of possible regions, which the user can choose from.

The list is maintained manually, since I could only find APIs to list regions for EC2, not CloudWatch. I'll try and check periodically, but hopefully someone will flag it if a region is missing. 