### PR TITLE
Remove "ignore: brands" from HACS validation

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -33,5 +33,3 @@ jobs:
           uses: "hacs/action@main"
           with:
             category: "integration"
-            # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-            ignore: "brands"


### PR DESCRIPTION
This is no longer needed, since a brand has been added. 