### PR TITLE
Use zipped releases for HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
     "name": "Amazon CloudWatch",
-    "render_readme": true
+    "render_readme": true,
+    "zip_release": true,
+    "filename": "custom_component_cloudwatch.zip"
 }


### PR DESCRIPTION
It's not clear whether there's a specific benefit to this approach, but let's start using zipped releases for HACS, since they're already being built and seem quite convenient. 